### PR TITLE
chore!: move to mconf organization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "bbb-diff",
-  "version": "1.1.0",
+  "name": "@mconf/bbb-diff",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bbb-diff",
-  "version": "1.1.0",
+  "name": "@mconf/bbb-diff",
+  "version": "1.2.0",
   "description": "BigBlueButton's text differencing wrapper for jsdiff",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,9 @@
   ],
   "author": "Pedro Beschorner Marin <pedrobmarin@gmail.com>",
   "license": "LGPL-3.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/pedrobmarin/bbb-diff/issues"
   },


### PR DESCRIPTION
Already published at npm as @mconf/bbb-diff

OBS.: Make sure to propagate this change to `mconf-live` `develop` repository